### PR TITLE
[dev] Upgrade development rake to address vulnerability

### DIFF
--- a/rack-brotli.gemspec
+++ b/rack-brotli.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'github-release', '~> 0.1'
   s.add_development_dependency 'minitest', '~> 5.6'
-  s.add_development_dependency 'rake', '~> 10.4', '>= 10.4.2'
+  s.add_development_dependency 'rake', '~> 12', '>= 12.3.3'
   s.add_development_dependency 'rdoc', '~> 3.12'
 
   s.has_rdoc = true


### PR DESCRIPTION
Addresses `rake` [CVE-2020-8130 (OS Command Injection in Rake)](https://github.com/advisories/GHSA-jppv-gw3r-w3q8).

`rake` is used only for development in `rack-brotli` so no production is affected.