### PR TITLE
Support environments with string literals frozen by default

### DIFF
--- a/lib/rack/brotli/deflater.rb
+++ b/lib/rack/brotli/deflater.rb
@@ -73,7 +73,8 @@ module Rack::Brotli
 
       def each(&block)
         @writer = block
-        buffer = ''
+        # Use String.new instead of '' to support environments with strings frozen by default.
+        buffer = String.new
         @body.each { |part|
           buffer << part
         }

--- a/test/deflater_spec.rb
+++ b/test/deflater_spec.rb
@@ -55,7 +55,8 @@ describe Rack::Brotli do
 
     # verify body
     unless options['skip_body_verify']
-      body_text = ''
+      # Use String.new instead of '' to support environments with strings frozen by default.
+      body_text = String.new
       body.each { |part| body_text << part }
 
       deflated_body = case expected_encoding


### PR DESCRIPTION
I was trying to run an app where string literals are frozen by default (using `RUBYOPT="--enable=frozen-string-literal"`), and was getting an exception here. 

String.new avoids that problem, even though it is uglier.

I converted the one in the spec, so that test pass too when run that way. 

Example:
`RUBYOPT="--enable=frozen-string-literal" rake`

Not sure this is super important, but it helps my use case without changing anything for anyone else. 